### PR TITLE
Add translation for ActiveModel::Validations

### DIFF
--- a/lib/validates_as_email_address/locale.rb
+++ b/lib/validates_as_email_address/locale.rb
@@ -5,5 +5,12 @@
         :invalid_email => ValidatesAsEmailAddress.invalid_email_message
       }
     }
+  },
+  :activemodel => {
+    :errors => {
+      :messages => {
+        :invalid_email => ValidatesAsEmailAddress.invalid_email_message
+      }
+    }
   }
 }}


### PR DESCRIPTION
I'm using non-persistent model with ActiveModel::Validations. Since `validates_as_email_address` contains translation string only for _ActiveRecord_, using the validation method with ActiveModel will have a problem of translation missing error.

``` ruby
class Foo
  include ActiveModel::Validations
  extend ValidatesAsEmailAddress

  attr_accessor :email
  validates_as_email_address  :email
end

foo = Foo.new
foo.valid?
foo.errors[:email]
# contains "translation missing: en.activemodel.errors.models.foo.attributes.email.invalid_email"
```

So I added a translation string for ActiveModel. I know it is possible to add custom translation but I think it's better to provide the same default translation to both ActiveRecord and ActiveModel classes
